### PR TITLE
Made SDCAlertView respect the current status bar height

### DIFF
--- a/SDCAlertView/SDCAlertViewController.m
+++ b/SDCAlertView/SDCAlertViewController.m
@@ -65,6 +65,10 @@ static CGFloat			const SDCAlertViewSpringAnimationVelocity = 0;
 	return self;
 }
 
+- (BOOL)prefersStatusBarHidden{
+    return CGRectGetHeight([[UIApplication sharedApplication] statusBarFrame]) == 0.0;
+}
+
 - (void)createViewHierarchy {
 	[self createDimmingView];
 	[self createAlertContainer];


### PR DESCRIPTION
It was forcing the status bar to be visible when it was otherwise hidden in my app. I made the alert's view controller respect the existing status bar height. Simple patch, doesn't seem to break anything in the demo app and it works in my app just fine. 
