### PR TITLE
Supports long button text, mimics UIAlertView behaviour

### DIFF
--- a/SDCAlertView/Source/SDCAlertViewContentView.m
+++ b/SDCAlertView/Source/SDCAlertViewContentView.m
@@ -319,6 +319,8 @@ static NSInteger const SDCAlertViewDefaultFirstButtonIndex = 0;
 	cell.backgroundColor = [UIColor clearColor];
 	cell.textLabel.textAlignment = NSTextAlignmentCenter;
     cell.textLabel.adjustsFontSizeToFitWidth = YES;
+    cell.textLabel.minimumScaleFactor = 0.5;
+    cell.textLabel.baselineAdjustment = UIBaselineAdjustmentAlignCenters;
 	cell.textLabel.enabled = [self isButtonAtIndexPathEnabled:indexPath inTableView:tableView];
 }
 


### PR DESCRIPTION
Hi, sorry to bug you again with a change, but I found that long texts are cut instead of reducing font size. I'm not sure if it was intentional, but UIAlertView scales down font to a minimum font size before cutting.
