### PR TITLE
fix buttons not showing up in iOS8

### DIFF
--- a/SDCAlertView/Source/SDCAlertViewContentView.m
+++ b/SDCAlertView/Source/SDCAlertViewContentView.m
@@ -586,10 +586,11 @@ static NSInteger const SDCAlertViewDefaultFirstButtonIndex = 0;
 		[self.buttonTopSeparatorView sdc_pinHeight:SDCAlertViewGetSeparatorThickness()];
 	}
 	
-	[self.suggestedButtonTableView sdc_pinHeight:self.suggestedButtonTableView.rowHeight];
+    const CGFloat minHeight = 44.0;
+	[self.suggestedButtonTableView sdc_pinHeight:MAX(minHeight, self.suggestedButtonTableView.rowHeight)];
 		
 	if ([elements containsObject:self.otherButtonsTableView]) {
-		[self.otherButtonsTableView sdc_pinHeight:self.otherButtonsTableView.rowHeight * [self.otherButtonsTableView numberOfRowsInSection:0]];
+		[self.otherButtonsTableView sdc_pinHeight:MAX(minHeight, self.otherButtonsTableView.rowHeight) * [self.otherButtonsTableView numberOfRowsInSection:0]];
 		
 		if ([self showsTableViewsSideBySide]) {
 			[self.suggestedButtonTableView sdc_alignEdges:UIRectEdgeRight withView:self];


### PR DESCRIPTION
With Xcode6 beta and the iOS8 simulator, the buttons do not show and you get Layout Constraints exceptions. This is due to rowHeight of both suggestedButtonTableView and otherButtonsTableView being -1.

Not sure if there's a better way to fix this or even if this is a bug in iOS8, but for now this fixes it for me and makes my app work again in iOS8
