### PR TITLE
Fixes invisible buttons on iOS 8

### DIFF
--- a/SDCAlertView/Source/SDCAlertViewContentView.m
+++ b/SDCAlertView/Source/SDCAlertViewContentView.m
@@ -22,6 +22,7 @@ static UIEdgeInsets const SDCAlertViewTextFieldBackgroundViewInsets = {0, 2, 0, 
 static UIEdgeInsets const SDCAlertViewTextFieldTextInsets = {0, 4, 0, 4};
 static CGFloat const SDCAlertViewPrimaryTextFieldHeight = 30;
 static CGFloat const SDCAlertViewSecondaryTextFieldHeight = 29;
+static CGFloat const SDCAlertViewButtonTableViewRowHeight = 44;
 
 static CGFloat const SDCAlertViewSeparatorThickness = 1;
 CGFloat SDCAlertViewGetSeparatorThickness() {
@@ -162,6 +163,7 @@ static NSInteger const SDCAlertViewDefaultFirstButtonIndex = 0;
 	tableView.separatorInset = UIEdgeInsetsZero;
 	tableView.separatorColor = [UIColor clearColor];
 	tableView.scrollEnabled = NO;
+	tableView.rowHeight = SDCAlertViewButtonTableViewRowHeight;
 	return tableView;
 }
 


### PR DESCRIPTION
On iOS 8 (betas at least) the default rowHeight of the table views created seems to be -1, so alert views get shown without buttons. This change sets rowHeight explicitly to 44.
