### PR TITLE
Complain loudly when being used with incompatible UIAlertView.

### DIFF
--- a/SDCAlertView/Source/SDCAlertViewCoordinator.m
+++ b/SDCAlertView/Source/SDCAlertViewCoordinator.m
@@ -45,11 +45,8 @@
 	
 	if (self) {
 		_userWindow = [[UIApplication sharedApplication] keyWindow];
-#ifdef DEBUG
-		NSAssert(![NSStringFromClass([_userWindow class]) isEqualToString:@"_UIAlertControllerShimPresenterWindow"],
-		         @"Using SDCAlertView from an UIAlertView is unsupported and will result in a frozen screen");
-#endif
 		_transitionQueue = [NSMutableArray array];
+        [self validateUserWindow];
 	}
 	
 	return self;
@@ -63,6 +60,15 @@
 	});
 	
 	return sharedCoordinator;
+}
+
+#pragma mark - Validation
+
+- (void)validateUserWindow {
+#ifdef DEBUG
+    NSAssert(![NSStringFromClass([_userWindow class]) isEqualToString:@"_UIAlertControllerShimPresenterWindow"],
+             @"Using SDCAlertView from an UIAlertView is unsupported and will result in a frozen screen");
+#endif
 }
 
 #pragma mark - Transition Queue


### PR DESCRIPTION
This should make the incompatibility more obvious than a frozen screen.
