### PR TITLE
fixing legacy alert's contentView vertical autolayout spacing constraints

### DIFF
--- a/SDCAlertView/Source/SDCAlertViewContentView.m
+++ b/SDCAlertView/Source/SDCAlertViewContentView.m
@@ -664,7 +664,9 @@ static NSInteger const SDCAlertViewDefaultFirstButtonIndex = 0;
 	}
 	
 	if ([elements containsObject:self.customContentView]) {
-		[verticalVFL appendString:@"-[customContentView]"];
+		if ([verticalVFL hasSuffix:@"|"] == NO)
+			[verticalVFL appendString:@"-"];
+		[verticalVFL appendString:@"[customContentView]"];
 		hasContentOtherThanButtons = YES;
 	}
 	

--- a/SDCAlertView/Source/SDCAlertViewContentView.m
+++ b/SDCAlertView/Source/SDCAlertViewContentView.m
@@ -664,7 +664,7 @@ static NSInteger const SDCAlertViewDefaultFirstButtonIndex = 0;
 	}
 	
 	if ([elements containsObject:self.customContentView]) {
-		if ([verticalVFL hasSuffix:@"|"] == NO)
+		if (! [verticalVFL hasSuffix:@"|"])
 			[verticalVFL appendString:@"-"];
 		[verticalVFL appendString:@"[customContentView]"];
 		hasContentOtherThanButtons = YES;


### PR DESCRIPTION
In the corner case when no title and no message exist, the autolayout still injects a blank space above the contentView.  Fixes #74.