### PR TITLE
setting the attributed string of an action after setting font and color

### DIFF
--- a/SDCAlertView/Source/SDCAlertCollectionViewCell.m
+++ b/SDCAlertView/Source/SDCAlertCollectionViewCell.m
@@ -62,6 +62,9 @@
 }
 
 - (void)updateWithAction:(SDCAlertAction *)action visualStyle:(id<SDCAlertControllerVisualStyle>)visualStyle {
+	self.textLabel.font = [visualStyle fontForAction:action];
+	self.textLabel.textColor = [visualStyle textColorForAction:action];
+	
 	if (action.attributedTitle) {
 		self.textLabel.attributedText = action.attributedTitle;
 	} else {
@@ -69,9 +72,6 @@
 	}
 	
 	self.enabled = action.isEnabled;
-	
-	self.textLabel.font = [visualStyle fontForAction:action];
-	self.textLabel.textColor = [visualStyle textColorForAction:action];
 	
 	self.highlightedBackgroundView = visualStyle.actionViewHighlightBackgroundView;
 	[self.highlightedBackgroundView setTranslatesAutoresizingMaskIntoConstraints:NO];


### PR DESCRIPTION
fixes #66. 

This addresses a small bug where the visualStyle's font and color override any attributed string values.