### PR TITLE
Fix bug: Spacing between label and contentView 

### DIFF
--- a/SDCAlertView/Source/SDCAlertControllerScrollView.h
+++ b/SDCAlertView/Source/SDCAlertControllerScrollView.h
@@ -17,6 +17,8 @@
 @property (nonatomic, strong) NSAttributedString *title;
 @property (nonatomic, strong) NSAttributedString *message;
 
+@property (nonatomic, assign) BOOL shouldAllowRemovingSpacing;
+
 @property (nonatomic, strong) SDCAlertControllerTextFieldViewController *textFieldViewController;
 @property (nonatomic, strong) id<SDCAlertControllerVisualStyle> visualStyle;
 

--- a/SDCAlertView/Source/SDCAlertControllerScrollView.m
+++ b/SDCAlertView/Source/SDCAlertControllerScrollView.m
@@ -77,7 +77,12 @@
 	[self.titleLabel sdc_pinWidthToWidthOfView:self offset:-(self.visualStyle.contentPadding.left + self.visualStyle.contentPadding.right)];
 	
 	[self.messageLabel sdc_alignEdges:UIRectEdgeLeft|UIRectEdgeRight withView:self.titleLabel];
-	
+
+	CGFloat messageLabelSpacing = self.visualStyle.labelSpacing;
+	if (!self.titleLabel.text.length || !self.messageLabel.text.length) {
+		messageLabelSpacing = 0.f;
+	}
+
 	[self addConstraint:[NSLayoutConstraint constraintWithItem:self.titleLabel
 													 attribute:NSLayoutAttributeFirstBaseline
 													 relatedBy:NSLayoutRelationEqual
@@ -92,7 +97,7 @@
 														toItem:self.titleLabel
 													 attribute:NSLayoutAttributeLastBaseline
 													multiplier:1
-													  constant:self.visualStyle.labelSpacing]];
+													  constant:messageLabelSpacing]];
 	
 	if (self.textFieldViewController) {
 		[self.textFieldViewController.view sdc_alignEdges:UIRectEdgeLeft|UIRectEdgeRight withView:self.titleLabel];

--- a/SDCAlertView/Source/SDCAlertControllerScrollView.m
+++ b/SDCAlertView/Source/SDCAlertControllerScrollView.m
@@ -79,7 +79,7 @@
 	[self.messageLabel sdc_alignEdges:UIRectEdgeLeft|UIRectEdgeRight withView:self.titleLabel];
 
 	CGFloat messageLabelSpacing = self.visualStyle.labelSpacing;
-	if (!self.messageLabel.text.length) {
+	if (!self.messageLabel.text.length && self.shouldAllowRemovingSpacing) {
 		messageLabelSpacing = 0.f;
 	}
 
@@ -133,7 +133,10 @@
 	if (self.textFieldViewController) {
 		intrinsicHeight = CGRectGetMaxY(self.textFieldViewController.view.frame);
 	} else {
-        CGFloat spacing = self.titleLabel.text.length ? self.visualStyle.messageLabelBottomSpacing : 0.f;
+        CGFloat spacing = self.visualStyle.messageLabelBottomSpacing;
+        if (!self.titleLabel.text.length && self.shouldAllowRemovingSpacing) {
+            spacing = 0.f;
+        }
         intrinsicHeight = CGRectGetMaxY(self.messageLabel.frame) + spacing; // Not perfect, as padding it added from the bottom of the label, not its baseline
 	}
 	

--- a/SDCAlertView/Source/SDCAlertControllerScrollView.m
+++ b/SDCAlertView/Source/SDCAlertControllerScrollView.m
@@ -79,7 +79,7 @@
 	[self.messageLabel sdc_alignEdges:UIRectEdgeLeft|UIRectEdgeRight withView:self.titleLabel];
 
 	CGFloat messageLabelSpacing = self.visualStyle.labelSpacing;
-	if (!self.titleLabel.text.length || !self.messageLabel.text.length) {
+	if (!self.messageLabel.text.length) {
 		messageLabelSpacing = 0.f;
 	}
 
@@ -133,7 +133,8 @@
 	if (self.textFieldViewController) {
 		intrinsicHeight = CGRectGetMaxY(self.textFieldViewController.view.frame);
 	} else {
-		intrinsicHeight = CGRectGetMaxY(self.messageLabel.frame) + self.visualStyle.messageLabelBottomSpacing; // Not perfect, as padding it added from the bottom of the label, not its baseline
+        CGFloat spacing = self.titleLabel.text.length ? self.visualStyle.messageLabelBottomSpacing : 0.f;
+        intrinsicHeight = CGRectGetMaxY(self.messageLabel.frame) + spacing; // Not perfect, as padding it added from the bottom of the label, not its baseline
 	}
 	
 	return CGSizeMake(UIViewNoIntrinsicMetric, intrinsicHeight);

--- a/SDCAlertView/Source/SDCAlertControllerView.m
+++ b/SDCAlertView/Source/SDCAlertControllerView.m
@@ -140,6 +140,7 @@ static NSString *const SDCAlertControllerCellReuseIdentifier = @"SDCAlertControl
 	[self applyCurrentStyleToAlertElements];
 	
 	[self.visualEffectView.contentView addSubview:self.scrollView];
+    [self.scrollView setShouldAllowRemovingSpacing:self.contentView.subviews.count];
 	[self.scrollView finalizeElements];
 	
 	[self.scrollView sdc_alignEdgesWithSuperview:UIRectEdgeLeft|UIRectEdgeTop|UIRectEdgeRight];


### PR DESCRIPTION
Hi,
Wanted to create an alert with no message and custom view inside and noticed a little bug. If the message label is empty or nil, there is still a spacing between title label and zero-height message label.
Before fix:
![before](https://cloud.githubusercontent.com/assets/4833192/6263886/7f657162-b826-11e4-8a6c-e5bfcdee85c0.png)
After fix:
![after](https://cloud.githubusercontent.com/assets/4833192/6263882/7541e904-b826-11e4-913a-e664c4e76e5b.png)
Spacing should now also be ok, if title label is empty/nil and contentView being not empty. If contentView is not empty, spacing is left as it was before. 