### PR TITLE
Use SDCAlertAction's attributedTitle.string if title not present. Fixes #85

### DIFF
--- a/SDCAlertView/Source/SDCAlertView.m
+++ b/SDCAlertView/Source/SDCAlertView.m
@@ -529,14 +529,19 @@ static CGFloat const SDCAlertViewLabelSpacing = 4;
 
 + (instancetype)alertViewWithAlertController:(SDCAlertController *)alertController {
 	SDCAlertAction *cancelAction = [self cancelActionForAlertController:alertController];
+	NSString *cancelActionTitle = cancelAction.title ?: cancelAction.attributedTitle.string;
 	SDCAlertView *alert = [[SDCAlertView alloc] initWithTitle:alertController.title
 													  message:alertController.message
 													 delegate:alertController
-											cancelButtonTitle:cancelAction.title
+											cancelButtonTitle:cancelActionTitle
 											otherButtonTitles:nil];
 	[alertController.actions enumerateObjectsUsingBlock:^(SDCAlertAction *action, NSUInteger idx, BOOL *stop) {
 		if (action != cancelAction) {
-			[alert addButtonWithTitle:action.title];
+			if (action.title) {
+				[alert addButtonWithTitle:action.title];
+			} else {
+				[alert addButtonWithTitle:action.attributedTitle.string];
+			}
 		}
 	}];
 	


### PR DESCRIPTION
This prevents the issue mentioned in #85. I also had to add a check for the `cancelAction` title, because otherwise it would not be displayed.