### PR TITLE
Fix infinite layout loop on iPad 2 (iOS 8.1)

### DIFF
--- a/SDCAlertView/Source/SDCAlertControllerScrollView.m
+++ b/SDCAlertView/Source/SDCAlertControllerScrollView.m
@@ -115,11 +115,6 @@
 
 - (void)layoutSubviews {
 	[super layoutSubviews];
-	[self invalidateIntrinsicContentSize];
-}
-
-- (void)invalidateIntrinsicContentSize {
-	[super invalidateIntrinsicContentSize];
 	self.contentSize = CGSizeMake(self.contentSize.width, [self intrinsicContentSize].height);
 }
 

--- a/SDCAlertView/Source/SDCAlertControllerView.m
+++ b/SDCAlertView/Source/SDCAlertControllerView.m
@@ -161,6 +161,7 @@ static NSString *const SDCAlertControllerCellReuseIdentifier = @"SDCAlertControl
 	
 	[self addSubview:self.visualEffectView];
 	[self.visualEffectView sdc_alignEdgesWithSuperview:UIRectEdgeAll];
+	[self.scrollView invalidateIntrinsicContentSize];
 }
 
 - (void)layoutSubviews {


### PR DESCRIPTION
If alert message has multiple lines, then app hangs on iPad 2 (iOS 8.1)
Sample code:
`SDCAlertController *alertController = [SDCAlertController alertControllerWithTitle: @"Title" message: @"1\n2\n3\n4" preferredStyle: SDCAlertControllerStyleAlert];`
`[alertController presentWithCompletion: nil];`