### PR TITLE
Remove declaration of `title` in SDCAlertController

### DIFF
--- a/SDCAlertView/Source/SDCAlertController.h
+++ b/SDCAlertView/Source/SDCAlertController.h
@@ -73,8 +73,6 @@ typedef NS_ENUM(NSInteger, SDCAlertControllerActionLayout) {
  */
 @property (nonatomic, readonly) NSArray *textFields;
 
-@property (nonatomic, copy) NSString *title;
-
 /**
  *  The attributed title for the alert. Both \c title and \c attributedTitle can be used to set the title of the alert,
  *  the title will be set to whichever was called last. That means that setting \c title to \c nil after setting the
@@ -161,7 +159,7 @@ typedef NS_ENUM(NSInteger, SDCAlertControllerActionLayout) {
  *		} else {
  *			// Keep using original alert
  *		}
- *		
+ *
  *		[alert presentWithCompletion:nil];
  */
 


### PR DESCRIPTION
Since [`UIViewController`](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIViewController_Class/) already has a `title` property, this declaration in `SDCAlertController.h` creates a warning (tested in XCode 6.3):

    SDCAlertController.h:76:39: Auto property synthesis will not synthesize property 'title'; it will be implemented by its superclass, use @dynamic to acknowledge intention

Removing this declaration solves the issue.
