### PR TITLE
configurable message text alignment

### DIFF
--- a/SDCAlertView/Source/SDCAlertControllerDefaultVisualStyle.m
+++ b/SDCAlertView/Source/SDCAlertControllerDefaultVisualStyle.m
@@ -60,7 +60,7 @@
 	return 24;
 }
 
-- (NSTextAlignment) messageTextAlignment {
+- (NSTextAlignment)messageTextAlignment {
 	return NSTextAlignmentCenter;
 }
 

--- a/SDCAlertView/Source/SDCAlertControllerDefaultVisualStyle.m
+++ b/SDCAlertView/Source/SDCAlertControllerDefaultVisualStyle.m
@@ -60,6 +60,10 @@
 	return 24;
 }
 
+- (NSTextAlignment) messageTextAlignment {
+	return NSTextAlignmentCenter;
+}
+
 #pragma mark - Actions
 
 - (CGFloat)actionViewHeight {

--- a/SDCAlertView/Source/SDCAlertControllerScrollView.m
+++ b/SDCAlertView/Source/SDCAlertControllerScrollView.m
@@ -59,6 +59,7 @@
 	
 	self.titleLabel.font = visualStyle.titleLabelFont;
 	self.messageLabel.font = visualStyle.messageLabelFont;
+	self.messageLabel.textAlignment = visualStyle.messageTextAlignment;
 	
 	self.titleLabel.textColor = visualStyle.titleLabelColor;
 	self.messageLabel.textColor = visualStyle.messageLabelColor;

--- a/SDCAlertView/Source/SDCAlertControllerVisualStyle.h
+++ b/SDCAlertView/Source/SDCAlertControllerVisualStyle.h
@@ -35,6 +35,8 @@
 @property (nonatomic, readonly) CGFloat labelSpacing;
 @property (nonatomic, readonly) CGFloat messageLabelBottomSpacing;
 
+@property (nonatomic, readonly) NSTextAlignment messageTextAlignment;
+
 #pragma mark - Actions
 
 @property (nonatomic, readonly) CGFloat actionViewHeight;


### PR DESCRIPTION
For multi-line messages in alerts, I wanted the text to be left-aligned. This PR adds a messageTextAlignment property to `SDCAlertControllerVisualStyle` and a default value (centered) to `SDCAlertControllerDefaultVisualStyle` to easily accomplish that.