### PR TITLE
set textLabel userInteractionEnabled to YES in SDCAlertCollectionViewCell

### DIFF
--- a/SDCAlertView/Source/SDCAlertCollectionViewCell.m
+++ b/SDCAlertView/Source/SDCAlertCollectionViewCell.m
@@ -67,8 +67,10 @@
 	
 	if (action.attributedTitle) {
 		self.textLabel.attributedText = action.attributedTitle;
+		self.accessibilityLabel = [action.attributedTitle string];
 	} else {
 		self.textLabel.text = action.title;
+		self.accessibilityLabel = action.title;
 	}
 	
 	self.enabled = action.isEnabled;

--- a/SDCAlertView/Source/SDCAlertCollectionViewCell.m
+++ b/SDCAlertView/Source/SDCAlertCollectionViewCell.m
@@ -26,6 +26,7 @@
 	if (self) {
 		_textLabel = [[UILabel alloc] init];
 		[_textLabel setTranslatesAutoresizingMaskIntoConstraints:NO];
+		self.isAccessibilityElement = YES;
 	}
 	
 	return self;


### PR DESCRIPTION
In iOS 7, with a UIAlertView and in iOS 8 with a UIAlertController, I was able to run the KIF test:
```objective-c
[tester tapViewWithAccessibilityLabel:@"OK"];
```
to dismiss an alert view. When I switched to SDCAlertView, tests were failing and I realized it's because the text label is not user interaction enabled, as it is in the UIAlertView and UIAlertController. Once I set the text label's `userInteractionEnabled` property to `YES`, the issue was resolved.