### PR TITLE
Fixed compilation in Xcode 7

### DIFF
--- a/SDCAlertView.podspec
+++ b/SDCAlertView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         =	'SDCAlertView'
-  s.version      =	'2.5.2'
+  s.version      =	'2.5.4'
   s.license      =	{ :type => 'MIT', :file => 'LICENSE' }
   s.authors      =	{ 'Scott Berrevoets' => 's.berrevoets@me.com' }
   s.summary      =	'SDCAlertView is a UIAlertView clone with added functionality including a contentView property'
@@ -10,6 +10,7 @@ Pod::Spec.new do |s|
   s.platform     =	:ios, '7.0'
   s.source       =	{ :git => 'https://github.com/sberrevoets/SDCAlertView.git', :tag => "v#{s.version}" }
   s.source_files =	'SDCAlertView/Source/*.{h,m}'
+  s.exclude_files = 'SDCAlertView/Source/SDCDemoViewController.{h,m}'
 
   s.requires_arc = true
   

--- a/SDCAlertView/Source/SDCDemoViewController.m
+++ b/SDCAlertView/Source/SDCDemoViewController.m
@@ -10,7 +10,7 @@
 
 #import "SDCAlertController.h"
 #import "SDCAlertView.h"
-#import <UIView+SDCAutoLayout.h>
+#import "UIView+SDCAutoLayout.h"
 
 @import MapKit;
 


### PR DESCRIPTION
Hello
I using SDCAlertView in my project via Cocoa Pods. In the Xcode 7 I got compilation error in SDCAlertView/Source/SDCDemoViewController.m:13. This pull request contains fix for this.
Also I excluded SDCDemoViewController from podspec, because DemoViewController is useful for demo project.
Please take a look on this