### PR TITLE
Fix pedantic CocoaPods warning about using quotes vs angles

### DIFF
--- a/SDCAlertView/Source/SDCDemoViewController.m
+++ b/SDCAlertView/Source/SDCDemoViewController.m
@@ -10,7 +10,7 @@
 
 #import "SDCAlertController.h"
 #import "SDCAlertView.h"
-#import <UIView+SDCAutoLayout.h>
+#import "UIView+SDCAutoLayout.h"
 
 @import MapKit;
 


### PR DESCRIPTION
This prevents any other library from using this library as a dependency with CP 0.38

```
➜  SDCAlertView git:(master) ✗ pod spec lint

 -> SDCAlertView (2.5.2)
    - ERROR | [iOS] Returned an unsuccessful exit code. You can use `--verbose` for more information.
    - ERROR | [iOS]  SDCAlertView/SDCAlertView/Source/SDCDemoViewController.m:13:9: error: 'UIView+SDCAutoLayout.h' file not found with <angled> include; use "quotes" instead

Analyzed 1 podspec.

[!] The spec did not pass validation, due to 2 errors.
```