### PR TITLE
Add font scaling to text label

### DIFF
--- a/SDCAlertView/Source/SDCAlertCollectionViewCell.m
+++ b/SDCAlertView/Source/SDCAlertCollectionViewCell.m
@@ -26,6 +26,9 @@
 	if (self) {
 		_textLabel = [[UILabel alloc] init];
 		[_textLabel setTranslatesAutoresizingMaskIntoConstraints:NO];
+		_textLabel.adjustsFontSizeToFitWidth = YES;
+		_textLabel.minimumScaleFactor = 0.5;
+		_textLabel.textAlignment = NSTextAlignmentCenter;
 		self.isAccessibilityElement = YES;
 	}
 	
@@ -89,6 +92,7 @@
 	
 	[self.contentView addSubview:self.textLabel];
 	[self.textLabel sdc_centerInSuperview];
+	[self.textLabel sdc_pinWidthToWidthOfView:self.contentView];
 }
 
 @end

--- a/SDCAlertView/Source/SDCAlertCollectionViewCell.m
+++ b/SDCAlertView/Source/SDCAlertCollectionViewCell.m
@@ -29,6 +29,7 @@
 		_textLabel.adjustsFontSizeToFitWidth = YES;
 		_textLabel.minimumScaleFactor = 0.5;
 		_textLabel.textAlignment = NSTextAlignmentCenter;
+		_textLabel.baselineAdjustment = UIBaselineAdjustmentAlignCenters;
 		self.isAccessibilityElement = YES;
 	}
 	

--- a/SDCAlertView/Source/SDCAlertCollectionViewCell.m
+++ b/SDCAlertView/Source/SDCAlertCollectionViewCell.m
@@ -30,6 +30,7 @@
 		_textLabel.minimumScaleFactor = 0.5;
 		_textLabel.textAlignment = NSTextAlignmentCenter;
 		_textLabel.baselineAdjustment = UIBaselineAdjustmentAlignCenters;
+		_textLabel.numberOfLines = 2;
 		self.isAccessibilityElement = YES;
 	}
 	


### PR DESCRIPTION
This ensures that labels scale down when the text inside of them is too big to fit in the SDCAlertCollectionViewCell.