### PR TITLE
Label background styling

### DIFF
--- a/Source/AlertControllerView.swift
+++ b/Source/AlertControllerView.swift
@@ -77,11 +77,15 @@ class AlertControllerView: UIView {
     }
 
     private func createBackground() {
-        let backgroundView = UIVisualEffectView(effect: UIBlurEffect(style: .ExtraLight))
-        backgroundView.translatesAutoresizingMaskIntoConstraints = false
+        if let color = self.visualStyle.backgroundColor {
+            self.backgroundColor = color
+        } else {
+            let backgroundView = UIVisualEffectView(effect: UIBlurEffect(style: .ExtraLight))
+            backgroundView.translatesAutoresizingMaskIntoConstraints = false
 
-        self.insertSubview(backgroundView, belowSubview: self.scrollView)
-        backgroundView.sdc_alignEdges(.All, withView: self)
+            self.insertSubview(backgroundView, belowSubview: self.scrollView)
+            backgroundView.sdc_alignEdges(.All, withView: self)
+        }
     }
 
     private func updateCollectionViewScrollDirection() {

--- a/Source/AlertControllerView.swift
+++ b/Source/AlertControllerView.swift
@@ -129,18 +129,24 @@ class AlertControllerView: UIView {
     }
 
     private func createTitleLabelConstraints() {
+        let widthOffset = self.visualStyle.contentPadding.left + self.visualStyle.contentPadding.right
+
         addConstraint(NSLayoutConstraint(item: self.titleLabel, attribute: .FirstBaseline, relatedBy: .Equal,
             toItem: self, attribute: .Top, multiplier: 1, constant: self.visualStyle.contentPadding.top))
-        self.titleLabel.sdc_alignEdges([.Left, .Right], withView: self)
+        self.titleLabel.sdc_pinWidthToWidthOfView(self, offset: -widthOffset)
+        self.titleLabel.sdc_alignHorizontalCenterWithView(self)
 
         pinBottomOfScrollViewToView(self.titleLabel, withPriority: UILayoutPriorityDefaultLow)
     }
 
     private func createMessageLabelConstraints() {
+        let widthOffset = self.visualStyle.contentPadding.left + self.visualStyle.contentPadding.right
+
         addConstraint(NSLayoutConstraint(item: self.messageLabel, attribute: .FirstBaseline,
             relatedBy: .Equal, toItem: self.titleLabel, attribute: .Baseline , multiplier: 1,
             constant: self.visualStyle.verticalElementSpacing))
-        self.messageLabel.sdc_alignEdges([.Left, .Right], withView: self)
+        self.messageLabel.sdc_pinWidthToWidthOfView(self, offset: -widthOffset)
+        self.messageLabel.sdc_alignHorizontalCenterWithView(self)
 
         pinBottomOfScrollViewToView(self.messageLabel, withPriority: UILayoutPriorityDefaultLow + 1)
     }
@@ -169,11 +175,13 @@ class AlertControllerView: UIView {
         if !self.elements.contains(self.contentView) { return }
 
         let aligningView = self.textFieldsViewController?.view ?? self.messageLabel
+        let widthOffset = self.visualStyle.contentPadding.left + self.visualStyle.contentPadding.right
 
         let topSpacing = self.visualStyle.verticalElementSpacing
         self.contentView.sdc_alignEdge(.Top, withEdge: .Bottom, ofView: aligningView, inset: topSpacing)
         self.contentView.sdc_alignHorizontalCenterWithView(self)
-        self.contentView.sdc_pinWidthToWidthOfView(self)
+        self.contentView.sdc_pinWidthToWidthOfView(self, offset: -widthOffset)
+        self.contentView.sdc_alignHorizontalCenterWithView(self)
 
         pinBottomOfScrollViewToView(self.contentView, withPriority: UILayoutPriorityDefaultLow + 3)
     }

--- a/Source/VisualStyle.swift
+++ b/Source/VisualStyle.swift
@@ -17,6 +17,9 @@ public protocol VisualStyle {
     /// The parallax magnitude
     var parallax: UIOffset { get }
 
+    /// The background color of the alert, if nil a blur effect view will be added
+    var backgroundColor: UIColor? { get }
+
     /// The font used for the title label
     var titleLabelFont: UIFont { get }
 
@@ -85,6 +88,8 @@ extension VisualStyle {
 
     public var margins: UIEdgeInsets { return UIEdgeInsets(top: 3, left: 0, bottom: 3, right: 0) }
     public var parallax: UIOffset { return UIOffset(horizontal: 15.75, vertical: 15.75) }
+
+    public var backgroundColor: UIColor? { return nil }
 
     public var titleLabelFont: UIFont { return UIFont.boldSystemFontOfSize(17) }
     public var messageLabelFont: UIFont { return UIFont.systemFontOfSize(13) }


### PR DESCRIPTION
As asked in my issue I just added the missing functionality to a fork of your project. Feel free to merge the changes back to your repository.

I also changed the layout constraints for the title and message label. I think it is a bit odd to define the vertical spacing for title and message label by using baseline attributes but for the content view attributes top and bottom are used. This leads to different vertical spaces between title label, message label and content view.