### PR TITLE
Resolve retain cycle when setActionTappedHandler. Fix a bug when first time add a action with "enable = false",the titleLabel of alertView is still enable(blue)

### DIFF
--- a/Source/Actions/AlertAction.swift
+++ b/Source/Actions/AlertAction.swift
@@ -66,5 +66,7 @@ public class AlertAction: NSObject {
         didSet { self.actionView?.enabled = self.enabled }
     }
 
-    var actionView: ActionCell?
+    var actionView: ActionCell? {
+        didSet { actionView?.enabled = self.enabled }
+    }
 }

--- a/Source/Actions/AlertAction.swift
+++ b/Source/Actions/AlertAction.swift
@@ -67,6 +67,6 @@ public class AlertAction: NSObject {
     }
 
     var actionView: ActionCell? {
-        didSet { actionView?.enabled = self.enabled }
+        didSet { self.actionView?.enabled = self.enabled }
     }
 }

--- a/Source/AlertController.swift
+++ b/Source/AlertController.swift
@@ -269,9 +269,9 @@ public class AlertController: UIViewController {
 
         self.alertView.prepareLayout()
 
-        self.alertView.setActionTappedHandler { action in
-            guard self.shouldDismissHandler?(action) != false else { return }
-            self.presentingViewController?.dismissViewControllerAnimated(true) {
+        self.alertView.setActionTappedHandler { [weak self] action in
+            guard self?.shouldDismissHandler?(action) != false else { return }
+            self?.presentingViewController?.dismissViewControllerAnimated(true) {
                 action.handler?(action)
             }
         }


### PR DESCRIPTION
1.Resolve retain cycle when setActionTappedHandler.
2.Fix a bug when first time add a action with "enable = false",the titleLabel of alertView is still enable(blue)