### PR TITLE
Update AlertAction.swift

### DIFF
--- a/Source/Actions/AlertAction.swift
+++ b/Source/Actions/AlertAction.swift
@@ -66,5 +66,7 @@ public class AlertAction: NSObject {
         didSet { self.actionView?.enabled = self.enabled }
     }
 
-    var actionView: ActionCell?
+    var actionView: ActionCell? {
+        didSet { actionView?.enabled = self.enabled }
+    }
 }


### PR DESCRIPTION
fix when first time add action with `action.enable = false`, `ActionCell`'s `titleLabel` is still enable(blue)