### PR TITLE
textColorForAction priority over tintColor

### DIFF
--- a/Source/Actions/ActionCell.swift
+++ b/Source/Actions/ActionCell.swift
@@ -5,6 +5,8 @@ final class ActionCell: UICollectionViewCell {
     @IBOutlet private(set) var titleLabel: UILabel!
     @IBOutlet private var highlightedBackgroundView: UIView!
 
+    private var titleLabelColorFromVisualStyle:UIColor?
+    
     var enabled = true {
         didSet { self.titleLabel.enabled = self.enabled }
     }
@@ -17,7 +19,10 @@ final class ActionCell: UICollectionViewCell {
         action.actionView = self
 
         self.titleLabel.font = visualStyle.font(forAction: action)
-        self.titleLabel.textColor = visualStyle.textColor(forAction: action)
+        
+        titleLabelColorFromVisualStyle = visualStyle.textColor(forAction: action)
+        self.titleLabel.textColor = titleLabelColorFromVisualStyle ?? self.tintColor
+        
         self.titleLabel.attributedText = action.attributedTitle
 
         self.highlightedBackgroundView.backgroundColor = visualStyle.actionHighlightColor
@@ -28,7 +33,7 @@ final class ActionCell: UICollectionViewCell {
 
     override func tintColorDidChange() {
         super.tintColorDidChange()
-        self.titleLabel.textColor = self.tintColor
+        self.titleLabel.textColor = titleLabelColorFromVisualStyle ?? self.tintColor
     }
 }
 

--- a/Source/Actions/ActionCell.swift
+++ b/Source/Actions/ActionCell.swift
@@ -5,7 +5,7 @@ final class ActionCell: UICollectionViewCell {
     @IBOutlet private(set) var titleLabel: UILabel!
     @IBOutlet private var highlightedBackgroundView: UIView!
 
-    private var titleLabelColorFromVisualStyle:UIColor?
+    private var textColor:UIColor?
     
     var enabled = true {
         didSet { self.titleLabel.enabled = self.enabled }
@@ -20,8 +20,8 @@ final class ActionCell: UICollectionViewCell {
 
         self.titleLabel.font = visualStyle.font(forAction: action)
         
-        titleLabelColorFromVisualStyle = visualStyle.textColor(forAction: action)
-        self.titleLabel.textColor = titleLabelColorFromVisualStyle ?? self.tintColor
+        self.textColor = visualStyle.textColor(forAction: action)
+        self.titleLabel.textColor = self.textColor ?? self.tintColor
         
         self.titleLabel.attributedText = action.attributedTitle
 
@@ -33,7 +33,7 @@ final class ActionCell: UICollectionViewCell {
 
     override func tintColorDidChange() {
         super.tintColorDidChange()
-        self.titleLabel.textColor = titleLabelColorFromVisualStyle ?? self.tintColor
+        self.titleLabel.textColor = textColor ?? self.tintColor
     }
 }
 

--- a/Source/Views/ActionSheetView.swift
+++ b/Source/Views/ActionSheetView.swift
@@ -44,7 +44,7 @@ final class ActionSheetView: AlertControllerView {
         self.cancelActionView?.layer.cornerRadius = self.visualStyle.cornerRadius
         self.cancelActionView?.layer.masksToBounds = true
 
-        self.cancelLabel?.textColor = self.visualStyle.textColor(forAction: self.cancelAction)
+        self.cancelLabel?.textColor = self.visualStyle.textColor(forAction: self.cancelAction) ?? self.tintColor
         self.cancelLabel?.font = self.visualStyle.font(forAction: self.cancelAction)
         let cancelButtonBackground = UIImage.imageWithColor(self.visualStyle.actionHighlightColor)
         self.cancelButton?.setBackgroundImage(cancelButtonBackground, forState: .Highlighted)
@@ -67,7 +67,7 @@ final class ActionSheetView: AlertControllerView {
 
     override func tintColorDidChange() {
         super.tintColorDidChange()
-        self.cancelLabel?.textColor = self.tintColor
+        self.cancelLabel?.textColor = self.visualStyle.textColor(forAction: self.cancelAction) ?? self.tintColor
     }
 
     @IBAction private func cancelTapped() {

--- a/Source/VisualStyle.swift
+++ b/Source/VisualStyle.swift
@@ -45,7 +45,7 @@ public protocol VisualStyle {
 
     - returns: The text color
     */
-    func textColor(forAction action: AlertAction?) -> UIColor
+    func textColor(forAction action: AlertAction?) -> UIColor?
 
     /**
     The font for a given action
@@ -86,12 +86,11 @@ extension VisualStyle {
     public var actionViewSeparatorColor: UIColor { return UIColor(white: 0.5, alpha: 0.5) }
     public var actionViewSeparatorThickness: CGFloat { return 1 / UIScreen.mainScreen().scale }
 
-    public func textColor(forAction action: AlertAction?) -> UIColor {
+    public func textColor(forAction action: AlertAction?) -> UIColor? {
         if action?.style == .Destructive {
             return UIColor.redColor()
-        } else {
-            return UIView().tintColor
         }
+        return nil
     }
 
     public var textFieldFont: UIFont { return UIFont.systemFontOfSize(13) }

--- a/Source/VisualStyle.swift
+++ b/Source/VisualStyle.swift
@@ -43,7 +43,7 @@ public protocol VisualStyle {
 
     - parameter action: The action that determines the text color
 
-    - returns: The text color
+    - returns: The text color. nil value will use the alert's tintColor.
     */
     func textColor(forAction action: AlertAction?) -> UIColor?
 

--- a/Source/VisualStyle.swift
+++ b/Source/VisualStyle.swift
@@ -87,10 +87,7 @@ extension VisualStyle {
     public var actionViewSeparatorThickness: CGFloat { return 1 / UIScreen.mainScreen().scale }
 
     public func textColor(forAction action: AlertAction?) -> UIColor? {
-        if action?.style == .Destructive {
-            return UIColor.redColor()
-        }
-        return nil
+        return action?.style == .Destructive ? UIColor.redColor() : nil
     }
 
     public var textFieldFont: UIFont { return UIFont.systemFontOfSize(13) }


### PR DESCRIPTION
This PR addresses #137 

PLEASE NOTE - introduces a breaking change to the method signature for textColorForAction:
```Swift
func textColor(forAction action: AlertAction?) -> UIColor
```
is now 
```Swift
func textColor(forAction action: AlertAction?) -> UIColor?
```