### PR TITLE
Added accessibility traits to the action buttons.

### DIFF
--- a/Source/Actions/ActionCell.swift
+++ b/Source/Actions/ActionCell.swift
@@ -28,6 +28,7 @@ final class ActionCell: UICollectionViewCell {
         self.highlightedBackgroundView.backgroundColor = visualStyle.actionHighlightColor
 
         self.accessibilityLabel = action.attributedTitle?.string
+        self.accessibilityTraits = UIAccessibilityTraitButton
         self.isAccessibilityElement = true
     }
 


### PR DESCRIPTION
If you check how the default UIAlerController works for Apple, when you have VoiceOver ON and you step on an action button, not only does it ready the label of the button,but it also states at the end "Button", so the user knows it can double tap to process the action. I would have never realized it myself, and I might think it's redundant, but I actually had a blind person bug this in my app. So hopefully you will accept the pull request.

Thanks!