### PR TITLE
Added Carthage/Build to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ profile
 DerivedData
 *.hmap
 *.ipa
+
+ # Carthage
+ Carthage/Build


### PR DESCRIPTION
When using the option `--use-submodules` with Carthage, the `Carthage/Build` directory appears in the submodule after `carthage build` making the submodule dirty.