### PR TITLE
Assign cancel action before laying out Action Sheet

### DIFF
--- a/Source/Views/ActionSheetView.swift
+++ b/Source/Views/ActionSheetView.swift
@@ -25,6 +25,8 @@ final class ActionSheetView: AlertControllerView {
     }
 
     override func prepareLayout() {
+        self.assignCancelAction()
+
         super.prepareLayout()
 
         self.collectionViewHeightConstraint.constant = self.actionsCollectionView.displayHeight
@@ -44,8 +46,6 @@ final class ActionSheetView: AlertControllerView {
         let showContentView = self.contentView.subviews.count > 0
         self.contentView.isHidden = !showContentView
         self.contentViewConstraints.forEach { $0.isActive = showContentView }
-
-        self.assignCancelAction()
     }
 
     override func highlightAction(for sender: UIPanGestureRecognizer) {


### PR DESCRIPTION
To ensure the cancel action isn’t duplicated and the action sheet’s height is correct, the cancel action should be assigned before any `prepareLayout()` is undertaken.

This resolves the issue where the cancel action would show twice in an ActionSheet since SDCAlertView version 7.0.

# Before:
![simulator screen shot 5 oct 2016 11 00 12 am](https://cloud.githubusercontent.com/assets/7020926/19096774/ea3cc1d2-8aea-11e6-927b-1f7f35d57f79.png)

# After:
![simulator screen shot 5 oct 2016 10 59 53 am](https://cloud.githubusercontent.com/assets/7020926/19096776/ed62eeae-8aea-11e6-8e52-fdb18c4b9f70.png)