### PR TITLE
Fix release cycle in assignResponder block

### DIFF
--- a/Source/AlertController.swift
+++ b/Source/AlertController.swift
@@ -30,7 +30,9 @@ public enum ActionLayout: Int {
 @objc(SDCAlertController)
 public class AlertController: UIViewController {
 
-    private lazy var assignResponder: () -> Bool = { [unowned self] () in self.textFields?.first?.becomeFirstResponder() ?? false }
+    private lazy var assignResponder: () -> Bool = { [unowned self] () in
+        self.textFields?.first?.becomeFirstResponder() ?? false
+    }
 
     /// The alert's title. Directly uses `attributedTitle` without any attributes.
     override public var title: String? {

--- a/Source/AlertController.swift
+++ b/Source/AlertController.swift
@@ -30,7 +30,7 @@ public enum ActionLayout: Int {
 @objc(SDCAlertController)
 public class AlertController: UIViewController {
 
-    private lazy var assignResponder: () -> Bool = { self.textFields?.first?.becomeFirstResponder() ?? false }
+    private lazy var assignResponder: () -> Bool = { [unowned self] () in self.textFields?.first?.becomeFirstResponder() ?? false }
 
     /// The alert's title. Directly uses `attributedTitle` without any attributes.
     override public var title: String? {


### PR DESCRIPTION
In assignResponder a reference to self needs to be captured as unowned (or maybe weak), otherwise capturing as strong reference will create a release cycle.