### PR TITLE
fix allowed interface orientations

### DIFF
--- a/Source/AlertController.swift
+++ b/Source/AlertController.swift
@@ -234,6 +234,10 @@ public class AlertController: UIViewController {
         return self.presentingViewController?.preferredStatusBarStyle ?? .default
     }
 
+    public override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return self.presentingViewController?.supportedInterfaceOrientations ?? super.supportedInterfaceOrientations
+    }
+
     // MARK: - Private
 
     private func listenForKeyboardChanges() {


### PR DESCRIPTION
When a AlertController is presented by a view controller which supports only landscape orientation, the AlertController should stay in landscape as well. Currently, the AlertController allows portrait mode. So, when the user rotates the device (while the AlertController is displayed), the presenting view controller is layed out in portrait, which it has not been designed for, resulting in pink elephants.