### PR TITLE
Bug Fix When Dismiss Alert Controller in iOS 11

### DIFF
--- a/Source/AlertController.swift
+++ b/Source/AlertController.swift
@@ -226,7 +226,10 @@ public class AlertController: UIViewController {
         // http://stackoverflow.com/a/19580888/751268
 
         if self.behaviors?.contains(.AutomaticallyFocusTextField) == true {
+          // prevent to hold the keyboard when alert being dismissed
+          if !self.isBeingDismissed {
             _ = self.assignResponder()
+          }
         }
     }
 


### PR DESCRIPTION
Hi, 

I found a bug when create AlertController with TextField. 
Apparently when i was trying to close or dimiss my alert controller the keyboard won't be dismissed, while the expected behaviour it should be (CMIIW). 

![simulator screen shot - iphone 6 - 2017-09-21 at 17 42 31](https://user-images.githubusercontent.com/358391/30689695-4f5ceb3c-9ef4-11e7-9fed-8711e15ff470.png)
![simulator screen shot - iphone 6 - 2017-09-21 at 17 42 37](https://user-images.githubusercontent.com/358391/30689709-5d1ccd28-9ef4-11e7-8ec4-8cf34c8014be.png)

In this pull request, i am trying to check whether alert controller is being dismissed or not, If it is being dismissed then it wont invoke the assignResponder() function. So that when we dismissing alert controller , the keyboard will be dismissed too. 

PS: This bug Only happened in iOS 11 


