### PR TITLE
Make framework extension-safe

### DIFF
--- a/Example/DemoViewController.swift
+++ b/Example/DemoViewController.swift
@@ -46,7 +46,7 @@ final class DemoViewController: UITableViewController {
 
         alert.actionLayout = ActionLayout(rawValue: self.buttonLayoutControl.selectedSegmentIndex)!
         addContentToAlert(alert)
-        alert.present()
+        alert.sdc_present()
     }
 
     private func addContentToAlert(_ alert: AlertController) {

--- a/Example/TestsViewController.swift
+++ b/Example/TestsViewController.swift
@@ -13,28 +13,28 @@ class TestsViewController: UITableViewController {
                 let alert = AlertController(title: "Title", message: "Message")
                 alert.addAction(AlertAction(title: "OK", style: .normal))
                 alert.addAction(AlertAction(title: "Cancel", style: .preferred))
-                alert.present()
+                alert.sdc_present()
 
             case 2:
                 let alert = AlertController(title: "Title", message: "Message")
                 alert.addAction(AlertAction(title: "OK", style: .normal))
                 alert.addAction(AlertAction(title: "Cancel", style: .preferred))
                 alert.shouldDismissHandler = { $0?.title == "Cancel" }
-                alert.present()
+                alert.sdc_present()
 
             case 4:
                 let alert = AlertController(title: "Title", message: "Message")
                 alert.addAction(AlertAction(title: "OK", style: .normal))
                 alert.addAction(AlertAction(title: "Cancel", style: .preferred))
                 alert.addAction(AlertAction(title: "Button", style: .normal))
-                alert.present()
+                alert.sdc_present()
 
             case 5:
                 let alert = AlertController(title: "Title", message: "Message")
                 alert.actionLayout = .vertical
                 alert.addAction(AlertAction(title: "OK", style: .normal))
                 alert.addAction(AlertAction(title: "Cancel", style: .preferred))
-                alert.present()
+                alert.sdc_present()
 
             case 6:
                 let alert = AlertController(title: "Title", message: "Message")
@@ -42,7 +42,7 @@ class TestsViewController: UITableViewController {
                 alert.addAction(AlertAction(title: "OK", style: .normal))
                 alert.addAction(AlertAction(title: "Cancel", style: .preferred))
                 alert.addAction(AlertAction(title: "Button", style: .normal))
-                alert.present()
+                alert.sdc_present()
 
             case 7:
                 let alert = AlertController(title: "Title", message: "Message")
@@ -50,7 +50,7 @@ class TestsViewController: UITableViewController {
                     textField.text = "Sample text"
                 }
                 alert.addAction(AlertAction(title: "OK", style: .preferred))
-                alert.present()
+                alert.sdc_present()
 
             case 8:
                 let alert = AlertController(title: "Title", message: "Message")
@@ -62,21 +62,21 @@ class TestsViewController: UITableViewController {
                 spinner.centerXAnchor.constraint(equalTo: contentView.centerXAnchor).isActive = true
                 spinner.topAnchor.constraint(equalTo: contentView.topAnchor).isActive = true
                 spinner.bottomAnchor.constraint(equalTo: contentView.bottomAnchor).isActive = true
-                alert.present()
+                alert.sdc_present()
 
             case 9:
                 let alert = AlertController(title: "Title", message: "Message")
                 let action = AlertAction(title: "OK", style: .normal)
                 action.accessibilityIdentifier = "button"
                 alert.addAction(action)
-                alert.present()
+                alert.sdc_present()
 
             case 10:
                 let alert = AlertController(title: "Title", message: "Message", preferredStyle: .actionSheet)
                 let action = AlertAction(title: "OK", style: .normal)
                 action.accessibilityIdentifier = "button"
                 alert.addAction(action)
-                alert.present()
+                alert.sdc_present()
             
             default: break
         }

--- a/SDCAlertView.xcodeproj/project.pbxproj
+++ b/SDCAlertView.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		0BA53BDB1F31D23D003854F3 /* UIView+Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA53BDA1F31D23D003854F3 /* UIView+Accessibility.swift */; };
+		A8C1D0661F827E2B004692DB /* UIViewController+Extension.m in Sources */ = {isa = PBXBuildFile; fileRef = A8C1D0651F827E2B004692DB /* UIViewController+Extension.m */; };
+		A8C1D0681F827E3B004692DB /* UIViewController+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = A8C1D0671F827E36004692DB /* UIViewController+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D23B53751BF473BC00AB5BBE /* AlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23B53741BF473BC00AB5BBE /* AlertView.swift */; };
 		D23B53771BF473CC00AB5BBE /* ActionSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23B53761BF473CC00AB5BBE /* ActionSheetView.swift */; };
 		D2515EC41BC1A7D500ED606F /* SDCAlertView.h in Headers */ = {isa = PBXBuildFile; fileRef = D2515EC31BC1A7D500ED606F /* SDCAlertView.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -19,7 +21,6 @@
 		D2515ED21BC1A85200ED606F /* AnimationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C30A791BC120C900984652 /* AnimationController.swift */; };
 		D2515ED31BC1A85200ED606F /* PresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C30A7A1BC120C900984652 /* PresentationController.swift */; };
 		D2515ED41BC1A85200ED606F /* Transition.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C30A7B1BC120C900984652 /* Transition.swift */; };
-		D2515ED51BC1A85200ED606F /* UIViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C30A7C1BC120C900984652 /* UIViewController+Extension.swift */; };
 		D2515ED61BC1A85800ED606F /* TextFieldCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C30A7E1BC120C900984652 /* TextFieldCell.swift */; };
 		D2515ED71BC1A85800ED606F /* TextFieldCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = D2C30A7F1BC120C900984652 /* TextFieldCell.xib */; };
 		D2515ED81BC1A85800ED606F /* TextFieldsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C30A801BC120C900984652 /* TextFieldsViewController.swift */; };
@@ -34,6 +35,8 @@
 
 /* Begin PBXFileReference section */
 		0BA53BDA1F31D23D003854F3 /* UIView+Accessibility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+Accessibility.swift"; sourceTree = "<group>"; };
+		A8C1D0651F827E2B004692DB /* UIViewController+Extension.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+Extension.m"; sourceTree = "<group>"; };
+		A8C1D0671F827E36004692DB /* UIViewController+Extension.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Extension.h"; sourceTree = "<group>"; };
 		D23B53741BF473BC00AB5BBE /* AlertView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlertView.swift; sourceTree = "<group>"; };
 		D23B53761BF473CC00AB5BBE /* ActionSheetView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActionSheetView.swift; sourceTree = "<group>"; };
 		D2515EC11BC1A7D500ED606F /* SDCAlertView.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SDCAlertView.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -52,7 +55,6 @@
 		D2C30A791BC120C900984652 /* AnimationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimationController.swift; sourceTree = "<group>"; };
 		D2C30A7A1BC120C900984652 /* PresentationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresentationController.swift; sourceTree = "<group>"; };
 		D2C30A7B1BC120C900984652 /* Transition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Transition.swift; sourceTree = "<group>"; };
-		D2C30A7C1BC120C900984652 /* UIViewController+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extension.swift"; sourceTree = "<group>"; };
 		D2C30A7E1BC120C900984652 /* TextFieldCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFieldCell.swift; sourceTree = "<group>"; };
 		D2C30A7F1BC120C900984652 /* TextFieldCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = TextFieldCell.xib; sourceTree = "<group>"; };
 		D2C30A801BC120C900984652 /* TextFieldsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFieldsViewController.swift; sourceTree = "<group>"; };
@@ -128,7 +130,8 @@
 				D2C30A791BC120C900984652 /* AnimationController.swift */,
 				D2C30A7A1BC120C900984652 /* PresentationController.swift */,
 				D2C30A7B1BC120C900984652 /* Transition.swift */,
-				D2C30A7C1BC120C900984652 /* UIViewController+Extension.swift */,
+				A8C1D0671F827E36004692DB /* UIViewController+Extension.h */,
+				A8C1D0651F827E2B004692DB /* UIViewController+Extension.m */,
 			);
 			path = Presentation;
 			sourceTree = "<group>";
@@ -167,6 +170,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D2515EC41BC1A7D500ED606F /* SDCAlertView.h in Headers */,
+				A8C1D0681F827E3B004692DB /* UIViewController+Extension.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -204,7 +208,7 @@
 				TargetAttributes = {
 					D2515EC01BC1A7D500ED606F = {
 						CreatedOnToolsVersion = 7.0.1;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0900;
 						ProvisioningStyle = Manual;
 					};
 				};
@@ -246,9 +250,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				D253B1C81C2AC78D00C37E0F /* AlertBehaviors.swift in Sources */,
-				D2515ED51BC1A85200ED606F /* UIViewController+Extension.swift in Sources */,
 				D2515ED21BC1A85200ED606F /* AnimationController.swift in Sources */,
 				D2515ED81BC1A85800ED606F /* TextFieldsViewController.swift in Sources */,
+				A8C1D0661F827E2B004692DB /* UIViewController+Extension.m in Sources */,
 				D2515ED11BC1A84D00ED606F /* AlertAction.swift in Sources */,
 				D2515ED31BC1A85200ED606F /* PresentationController.swift in Sources */,
 				D23B53771BF473CC00AB5BBE /* ActionSheetView.swift in Sources */,
@@ -273,6 +277,8 @@
 		D2515EC71BC1A7D500ED606F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -304,6 +310,8 @@
 		D2515EC81BC1A7D500ED606F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;

--- a/Source/AlertController+Convenience.swift
+++ b/Source/AlertController+Convenience.swift
@@ -19,7 +19,6 @@ public extension AlertController {
             alertController.contentView.addSubview(customView)
         }
 
-        alertController.present()
         return alertController
     }
 
@@ -37,7 +36,6 @@ public extension AlertController {
     {
         let alertController = AlertController(title: title, message: message, preferredStyle: .actionSheet)
         actions.forEach { alertController.addAction(AlertAction(title: $0, style: .normal)) }
-        alertController.present()
         return alertController
     }
 
@@ -52,7 +50,6 @@ public extension AlertController {
         let alertController = AlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         actions.forEach { alertController.addAction(AlertAction(title: $0, style: .normal)) }
         alertController.contentView.addSubview(view)
-        alertController.present()
         return alertController
     }
 }

--- a/Source/AlertController.swift
+++ b/Source/AlertController.swift
@@ -223,16 +223,6 @@ public class AlertController: UIViewController {
         self.textFields = currentTextFields + [textField]
     }
 
-    /// Presents the alert.
-    ///
-    /// - parameter animated:   Whether to present the alert animated.
-    /// - parameter completion: An optional closure that's called when the presentation finishes.
-    @objc(presentAnimated:completion:)
-    public func present(animated: Bool = true, completion: (() -> Void)? = nil) {
-        let topViewController = UIViewController.topViewController()
-        topViewController?.present(self, animated: animated, completion: completion)
-    }
-
     /// Dismisses the alert.
     ///
     /// - parameter animated:   Whether to dismiss the alert animated.

--- a/Source/Presentation/UIViewController+Extension.h
+++ b/Source/Presentation/UIViewController+Extension.h
@@ -1,0 +1,8 @@
+@import UIKit;
+
+@interface UIViewController (SDCAlertView)
+
+- (void)sdc_present NS_EXTENSION_UNAVAILABLE_IOS("");
+- (void)sdc_presentAnimated:(BOOL)animated completion:(void (^_Nullable)(void))completion NS_EXTENSION_UNAVAILABLE_IOS("");
+
+@end

--- a/Source/Presentation/UIViewController+Extension.m
+++ b/Source/Presentation/UIViewController+Extension.m
@@ -1,0 +1,43 @@
+#import <SDCAlertView/UIViewController+Extension.h>
+
+@interface UIViewController (SDCAlertViewPrivate)
+
++ (nullable UIViewController *)sdc_topViewController NS_EXTENSION_UNAVAILABLE_IOS("");
++ (nullable UIViewController *)sdc_topViewControllerPresentedFrom:(nullable UIViewController *)controller NS_EXTENSION_UNAVAILABLE_IOS("");
+
+@end
+
+
+@implementation UIViewController (SDCAlertView)
+
++ (nullable UIViewController *)sdc_topViewController {
+    return [self sdc_topViewControllerPresentedFrom:nil];
+}
+
++ (nullable UIViewController *)sdc_topViewControllerPresentedFrom:(nullable UIViewController *)controller {
+    UIViewController *viewController = controller ?: [UIApplication sharedApplication].keyWindow.rootViewController;
+
+    if ([viewController isKindOfClass:[UINavigationController class]] && ((UINavigationController *)viewController).viewControllers.count > 0) {
+        return [self sdc_topViewControllerPresentedFrom:((UINavigationController *)viewController).viewControllers.lastObject];
+    }
+
+    if ([viewController isKindOfClass:[UITabBarController class]] && ((UITabBarController *)viewController).selectedViewController) {
+        return [self sdc_topViewControllerPresentedFrom:((UITabBarController *)viewController).selectedViewController];
+    }
+
+    if (viewController.presentedViewController != nil) {
+        return [self sdc_topViewControllerPresentedFrom:viewController.presentedViewController];
+    }
+
+    return viewController;
+}
+
+- (void)sdc_present {
+    [self sdc_presentAnimated:YES completion:nil];
+}
+
+- (void)sdc_presentAnimated:(BOOL)animated completion:(void (^_Nullable)(void))completion {
+    [[[UIViewController class] sdc_topViewController] presentViewController:self animated:animated completion:completion];
+}
+
+@end

--- a/Source/Supporting Files/SDCAlertView.h
+++ b/Source/Supporting Files/SDCAlertView.h
@@ -6,4 +6,4 @@ FOUNDATION_EXPORT double SDCAlertViewVersionNumber;
 //! Project version string for SDCAlertView.
 FOUNDATION_EXPORT const unsigned char SDCAlertViewVersionString[];
 
-// In this header, you should import all the public headers of your framework using statements like #import <SDCAlertView/PublicHeader.h>
+#import <SDCAlertView/UIViewController+Extension.h>


### PR DESCRIPTION
This makes the framework safe for use in app extensions. To achieve this, methods for finding the top view controller and presenting the alert on it were converted from Swift to Objective-C and marked with `NS_EXTENSION_UNAVAILABLE_IOS`.