### PR TITLE
Allow autosizing of custom content views.

### DIFF
--- a/Example/DemoViewController.swift
+++ b/Example/DemoViewController.swift
@@ -58,8 +58,17 @@ final class DemoViewController: UITableViewController {
                 spinner.startAnimating()
                 contentView.addSubview(spinner)
                 spinner.centerXAnchor.constraint(equalTo: contentView.centerXAnchor).isActive = true
-                spinner.topAnchor.constraint(equalTo: contentView.topAnchor).isActive = true
-                spinner.bottomAnchor.constraint(equalTo: contentView.bottomAnchor).isActive = true
+                spinner.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 20).isActive = true
+            
+                let label = UILabel()
+                label.translatesAutoresizingMaskIntoConstraints = false
+                contentView.addSubview(label)
+                label.text = "Loading..."
+                label.textAlignment = .center
+                spinner.bottomAnchor.constraint(equalTo: label.topAnchor, constant: -8).isActive = true
+                label.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 10).isActive = true
+                label.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: 10).isActive = true
+                label.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -20).isActive = true
             case 2:
                 let contentView = alert.contentView
                 let switchControl = UISwitch()
@@ -67,8 +76,8 @@ final class DemoViewController: UITableViewController {
                 switchControl.translatesAutoresizingMaskIntoConstraints = false
                 contentView.addSubview(switchControl)
                 switchControl.centerXAnchor.constraint(equalTo: contentView.centerXAnchor).isActive = true
-                switchControl.topAnchor.constraint(equalTo: contentView.topAnchor).isActive = true
-                switchControl.bottomAnchor.constraint(equalTo: contentView.bottomAnchor).isActive = true
+                switchControl.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 20).isActive = true
+                switchControl.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -20).isActive = true
 
                 alert.message = "Disable switch to prevent alert dismissal"
 
@@ -83,9 +92,11 @@ final class DemoViewController: UITableViewController {
                     constant: 20).isActive = true
                 bar.trailingAnchor.constraint(equalTo: alert.contentView.trailingAnchor,
                     constant: -20).isActive = true
-                bar.topAnchor.constraint(equalTo: alert.contentView.topAnchor).isActive = true
-                bar.bottomAnchor.constraint(equalTo: alert.contentView.bottomAnchor).isActive = true
-
+                bar.topAnchor.constraint(equalTo: alert.contentView.topAnchor,
+                                         constant: 20).isActive = true
+                bar.bottomAnchor.constraint(equalTo: alert.contentView.bottomAnchor,
+                                            constant: -20).isActive = true
+                bar.heightAnchor.constraint(equalToConstant: 20).isActive = true
                 Timer.scheduledTimer(timeInterval: 0.01, target: self, selector:
                     #selector(updateProgressBar), userInfo: bar, repeats: true)
             default: break

--- a/Source/AlertController.swift
+++ b/Source/AlertController.swift
@@ -27,7 +27,7 @@ public enum ActionLayout: Int {
 
 @objc(SDCAlertController)
 public class AlertController: UIViewController {
-
+    
     private var verticalCenter: NSLayoutConstraint?
     private var actionSheetBottomConstraint: NSLayoutConstraint?
     
@@ -36,28 +36,28 @@ public class AlertController: UIViewController {
         get { return self.attributedTitle?.string }
         set { self.attributedTitle = newValue.map(NSAttributedString.init) }
     }
-
+    
     /// The alert's message. Directly uses `attributedMessage` without any attributes.
     @objc
     public var message: String? {
         get { return self.attributedMessage?.string }
         set { self.attributedMessage = newValue.map(NSAttributedString.init) }
     }
-
+    
     /// A stylized title for the alert.
     @objc
     public var attributedTitle: NSAttributedString? {
         get { return self.alert.title }
         set { self.alert.title = newValue }
     }
-
+    
     /// A stylized message for the alert.
     @objc
     public var attributedMessage: NSAttributedString? {
         get { return self.alert.message }
         set { self.alert.message = newValue }
     }
-
+    
     /// The alert's content view. This can be used to add custom views to your alert. The width of the content
     /// view is equal to the width of the alert, minus padding. The height must be defined manually since it
     /// depends on the size of the subviews.
@@ -65,13 +65,13 @@ public class AlertController: UIViewController {
     public var contentView: UIView {
         return self.alert.contentView
     }
-
+    
     /// The alert's actions (buttons).
     @objc
     private(set) public var actions = [AlertAction]() {
         didSet { self.alert.actions = self.actions }
     }
-
+    
     /// The alert's preferred action, if one is set. Setting this value to an action that wasn't already added
     /// to the array will add it and override its style to `.preferred`. Setting this value to `nil` will
     /// remove the preferred style from all actions.
@@ -84,7 +84,7 @@ public class AlertController: UIViewController {
         set {
             if let action = newValue {
                 action.style = .preferred
-
+                
                 if self.actions.index(where: { $0 == newValue }) == nil {
                     self.actions.append(action)
                 }
@@ -93,21 +93,21 @@ public class AlertController: UIViewController {
             }
         }
     }
-
+    
     /// The layout of the actions in the alert.
     @objc
     public var actionLayout: ActionLayout {
         get { return (self.alert as? AlertView)?.actionLayout ?? .automatic }
         set { (self.alert as? AlertView)?.actionLayout = newValue }
     }
-
+    
     /// The text fields that are added to the alert. Does nothing when used with an action sheet.
     @objc
     private(set) public var textFields: [UITextField]?
-
+    
     /// The alert's custom behaviors. See `AlertBehaviors` for possible options.
     public lazy var behaviors: AlertBehaviors = AlertBehaviors.defaultBehaviors(forStyle: self.preferredStyle)
-
+    
     /// A closure that, when set, returns whether the alert or action sheet should dismiss after the user taps
     /// on an action. If it returns false, the AlertAction handler will not be executed.
     @objc
@@ -117,40 +117,40 @@ public class AlertController: UIViewController {
     /// is enabled)
     @objc
     public var outsideTapHandler: (() -> Void)?
-
+    
     /// The visual style that applies to the alert or action sheet.
     @objc
     public lazy var visualStyle: AlertVisualStyle = AlertVisualStyle(alertStyle: self.preferredStyle)
-
+    
     /// The alert's presentation style.
     @objc
     private(set) public var preferredStyle: AlertControllerStyle = .alert
-
+    
     private let alert: UIView & AlertControllerViewRepresentable
     private lazy var transitionDelegate: Transition = Transition(alertStyle: self.preferredStyle)
-
+    
     // MARK: - Initialization
-
+    
     /// Create an alert with an stylized title and message. If no styles are necessary, consider using
     /// `init(title:message:preferredStyle:)`
-
+    
     ///
     /// - parameter attributedTitle:   An optional stylized title
     /// - parameter attributedMessage: An optional stylized message
     /// - parameter preferredStyle:    The preferred presentation style of the alert. Default is `alert`.
     @objc
     public convenience init(attributedTitle: NSAttributedString?, attributedMessage: NSAttributedString?,
-        preferredStyle: AlertControllerStyle = .alert)
+                            preferredStyle: AlertControllerStyle = .alert)
     {
         self.init(preferredStyle: preferredStyle)
         self.preferredStyle = preferredStyle
         self.commonInit()
-
+        
         self.attributedTitle = attributedTitle
         self.attributedMessage = attributedMessage
-
+        
     }
-
+    
     /// Creates an alert with a plain title and message. To add styles to the title or message, use
     /// `init(attributedTitle:attributedMessage:)`.
     ///
@@ -162,7 +162,7 @@ public class AlertController: UIViewController {
         self.init(preferredStyle: preferredStyle)
         self.preferredStyle = preferredStyle
         self.commonInit()
-
+        
         self.title = title
         self.message = message
     }
@@ -185,14 +185,36 @@ public class AlertController: UIViewController {
             customView.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor),
             customView.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor),
             customView.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor)
-        ])
+            ])
     }
-
+    
+    /// Creates an alert with a custom view controller above the buttons. The view will be autosized according to the layout of its contents (ie. treat your custom view like an auto sizing table view cell when you build it).
+    ///
+    /// - parameter customViewController: The view controller to display above the buttons
+    /// - parameter preferredStyle: The preferred presentation style of the alert. Default is `alert`.
+    @objc
+    public convenience init(customViewController: UIViewController, preferredStyle: AlertControllerStyle = .alert) {
+        self.init(preferredStyle: preferredStyle)
+        self.preferredStyle = preferredStyle
+        self.commonInit()
+        
+        customViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        self.addChildViewController(customViewController)
+        self.contentView.addSubview(customViewController.view)
+        
+        NSLayoutConstraint.activate([
+            customViewController.view.topAnchor.constraint(equalTo: self.contentView.topAnchor),
+            customViewController.view.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor),
+            customViewController.view.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor),
+            customViewController.view.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor)
+            ])
+    }
+    
     private init(preferredStyle: AlertControllerStyle) {
         switch preferredStyle {
         case .alert:
             self.alert = AlertView()
-
+            
         case .actionSheet:
             let nibName = String(describing: ActionSheetView.self)
             let objects = Bundle(for: ActionSheetView.self).loadNibNamed(nibName, owner: nil, options: nil)
@@ -202,26 +224,26 @@ public class AlertController: UIViewController {
                 self.alert = AlertView()
             }
         }
-
+        
         super.init(nibName: nil, bundle: nil)
     }
-
+    
     public required init?(coder aDecoder: NSCoder) {
         preconditionFailure("Please use one of the provided AlertController initializers")
     }
-
+    
     private func commonInit() {
         self.modalPresentationStyle = .custom
         self.transitioningDelegate = self.transitionDelegate
     }
-
+    
     public override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         self.textFields?.first?.resignFirstResponder()
     }
-
+    
     // MARK: - Public
-
+    
     /// Adds the provided action to the alert. Unlike the `UIAlertController` API, this method adds and shows
     /// buttons in the order they were added. This gives you the flexibility to place buttons of any style in
     /// any position.
@@ -231,7 +253,7 @@ public class AlertController: UIViewController {
     public func addAction(_ action: AlertAction) {
         self.actions.append(action)
     }
-
+    
     /// Adds a text field to the alert.
     ///
     /// - parameter configurationHandler: An optional closure that can be used to configure the text field,
@@ -244,7 +266,7 @@ public class AlertController: UIViewController {
         let currentTextFields = self.textFields ?? []
         self.textFields = currentTextFields + [textField]
     }
-
+    
     /// Presents the alert.
     ///
     /// - parameter animated:   Whether to present the alert animated.
@@ -254,7 +276,7 @@ public class AlertController: UIViewController {
         let topViewController = UIViewController.topViewController()
         topViewController?.present(self, animated: animated, completion: completion)
     }
-
+    
     /// Dismisses the alert.
     ///
     /// - parameter animated:   Whether to dismiss the alert animated.
@@ -263,30 +285,30 @@ public class AlertController: UIViewController {
     public override func dismiss(animated: Bool = true, completion: (() -> Void)? = nil) {
         self.presentingViewController?.dismiss(animated: animated, completion: completion)
     }
-
+    
     // MARK: - Override
-
+    
     public override func viewDidLoad() {
         super.viewDidLoad()
         self.listenForKeyboardChanges()
         self.configureAlertView()
     }
-
+    
     public override var preferredStatusBarStyle: UIStatusBarStyle {
         return self.presentingViewController?.preferredStatusBarStyle ?? .default
     }
-
+    
     public override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return self.presentingViewController?.supportedInterfaceOrientations ?? super.supportedInterfaceOrientations
     }
-
+    
     // MARK: - Private
-
+    
     private func listenForKeyboardChanges() {
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardChange),
                                                name: .UIKeyboardWillChangeFrame, object: nil)
     }
-
+    
     @objc
     private func keyboardChange(_ notification: Notification) {
         
@@ -305,31 +327,31 @@ public class AlertController: UIViewController {
         case .alert:
             self.verticalCenter?.constant = -deltaY / 2
         }
-
+        
         UIView.animateKeyframes(withDuration: duration, delay: 0.0, options: options, animations: {
             self.view.layoutIfNeeded()
         })
-}
+    }
     
     public override func becomeFirstResponder() -> Bool {
         if self.behaviors.contains(.automaticallyFocusTextField) {
             return self.textFields?.first?.becomeFirstResponder() ?? super.becomeFirstResponder()
         }
-
+        
         return super.becomeFirstResponder()
     }
-
+    
     private func configureAlertView() {
         self.alert.translatesAutoresizingMaskIntoConstraints = false
         self.alert.visualStyle = self.visualStyle
         self.alert.add(self.behaviors)
-
+        
         self.addTextFieldsIfNecessary()
         self.addChromeTapHandlerIfNecessary()
-
+        
         self.view.addSubview(self.alert)
         self.createViewConstraints()
-
+        
         self.alert.prepareLayout()
         self.alert.actionTappedHandler = { [weak self] action in
             if self?.shouldDismissHandler?(action) != false {
@@ -338,13 +360,13 @@ public class AlertController: UIViewController {
                 }
             }
         }
-
+        
         self.alert.layoutIfNeeded()
     }
-
+    
     private func createViewConstraints() {
         let margins = self.visualStyle.margins
-
+        
         switch self.preferredStyle {
         case .actionSheet:
             let bounds = self.presentingViewController?.view.bounds ?? self.view.bounds
@@ -355,8 +377,7 @@ public class AlertController: UIViewController {
                 self.alert.widthAnchor.constraint(equalToConstant: width * self.visualStyle.width),
                 self.alert.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
                 self.actionSheetBottomConstraint!,
-                self.alert.heightAnchor.constraint(lessThanOrEqualTo: self.view.heightAnchor,
-                                                   constant: -margins.top)
+                self.alert.topAnchor.constraint(greaterThanOrEqualTo: self.view.topAnchor, constant: margins.top)
                 ])
             
         case .alert:
@@ -375,29 +396,29 @@ public class AlertController: UIViewController {
             self.alert.setContentCompressionResistancePriority(priority, for: .vertical)
         }
     }
-
+    
     private func addTextFieldsIfNecessary() {
         guard let textFields = self.textFields, let alert = self.alert as? AlertView else {
             return
         }
-
+        
         let textFieldsViewController = TextFieldsViewController(textFields: textFields)
         textFieldsViewController.willMove(toParentViewController: self)
         self.addChildViewController(textFieldsViewController)
         alert.textFieldsViewController = textFieldsViewController
         textFieldsViewController.didMove(toParentViewController: self)
     }
-
+    
     private func addChromeTapHandlerIfNecessary() {
         if self.behaviors.contains(.dismissOnOutsideTap) {
             return
         }
-
+        
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(chromeTapped(_:)))
         tapGesture.cancelsTouchesInView = false
         self.view.addGestureRecognizer(tapGesture)
     }
-
+    
     @objc
     private func chromeTapped(_ sender: UITapGestureRecognizer) {
         if !self.alert.frame.contains(sender.location(in: self.view)) {
@@ -407,3 +428,4 @@ public class AlertController: UIViewController {
         }
     }
 }
+

--- a/Source/AlertController.swift
+++ b/Source/AlertController.swift
@@ -165,6 +165,27 @@ public class AlertController: UIViewController {
         self.title = title
         self.message = message
     }
+    
+    /// Creates an alert with a custom view above the buttons. The view will be autosized according to the layout of its contents (ie. treat your custom view like an auto sizing table view cell when you build it).
+    ///
+    /// - parameter customView:          The view to display above the buttons
+    /// - parameter preferredStyle: The preferred presentation style of the alert. Default is `alert`.
+    @objc
+    public convenience init(customView: UIView, preferredStyle: AlertControllerStyle = .alert) {
+        self.init(preferredStyle: preferredStyle)
+        self.preferredStyle = preferredStyle
+        self.commonInit()
+        
+        customView.translatesAutoresizingMaskIntoConstraints = false
+        self.contentView.addSubview(customView)
+        
+        NSLayoutConstraint.activate([
+            customView.topAnchor.constraint(equalTo: self.contentView.topAnchor),
+            customView.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor),
+            customView.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor),
+            customView.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor)
+        ])
+    }
 
     private init(preferredStyle: AlertControllerStyle) {
         switch preferredStyle {

--- a/Source/AlertController.swift
+++ b/Source/AlertController.swift
@@ -29,7 +29,8 @@ public enum ActionLayout: Int {
 public class AlertController: UIViewController {
 
     private var verticalCenter: NSLayoutConstraint?
-
+    private var actionSheetBottomConstraint: NSLayoutConstraint?
+    
     /// The alert's title. Directly uses `attributedTitle` without any attributes.
     override public var title: String? {
         get { return self.attributedTitle?.string }
@@ -288,15 +289,28 @@ public class AlertController: UIViewController {
 
     @objc
     private func keyboardChange(_ notification: Notification) {
-        let newFrameValue = notification.userInfo?[UIKeyboardFrameEndUserInfoKey] as? NSValue
-        guard let newFrame = newFrameValue?.cgRectValue else {
-            return
+        
+        guard let userInfo = notification.userInfo,
+            let beginRect = userInfo[UIKeyboardFrameBeginUserInfoKey] as? CGRect,
+            let targetRect = userInfo[UIKeyboardFrameEndUserInfoKey] as? CGRect else { return }
+        
+        let duration = userInfo[UIKeyboardAnimationDurationUserInfoKey] as? Double ?? 0.0
+        let curve = userInfo[UIKeyboardAnimationCurveUserInfoKey] as? UInt ?? 0
+        let options: UIViewKeyframeAnimationOptions = curve == 0 ? [] : UIViewKeyframeAnimationOptions(rawValue: curve)
+        let deltaY = beginRect.origin.y - targetRect.origin.y
+        
+        switch self.preferredStyle {
+        case .actionSheet:
+            self.actionSheetBottomConstraint?.constant += -deltaY
+        case .alert:
+            self.verticalCenter?.constant = -deltaY / 2
         }
 
-        self.verticalCenter?.constant = -newFrame.height / 2
-        self.alert.layoutIfNeeded()
-    }
-
+        UIView.animateKeyframes(withDuration: duration, delay: 0.0, options: options, animations: {
+            self.view.layoutIfNeeded()
+        })
+}
+    
     public override func becomeFirstResponder() -> Bool {
         if self.behaviors.contains(.automaticallyFocusTextField) {
             return self.textFields?.first?.becomeFirstResponder() ?? super.becomeFirstResponder()
@@ -332,32 +346,33 @@ public class AlertController: UIViewController {
         let margins = self.visualStyle.margins
 
         switch self.preferredStyle {
-            case .actionSheet:
-                let bounds = self.presentingViewController?.view.bounds ?? self.view.bounds
-                let width = min(bounds.width, bounds.height) - margins.left - margins.right
-                NSLayoutConstraint.activate([
-                    self.alert.widthAnchor.constraint(equalToConstant: width * self.visualStyle.width),
-                    self.alert.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
-                    self.alert.bottomAnchor.constraint(equalTo: self.view.bottomAnchor,
-                                                           constant: margins.bottom),
-                    self.alert.heightAnchor.constraint(lessThanOrEqualTo: self.view.heightAnchor,
-                                                           constant: -margins.top)
+        case .actionSheet:
+            let bounds = self.presentingViewController?.view.bounds ?? self.view.bounds
+            let width = min(bounds.width, bounds.height) - margins.left - margins.right
+            
+            self.actionSheetBottomConstraint = self.alert.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: margins.bottom)
+            NSLayoutConstraint.activate([
+                self.alert.widthAnchor.constraint(equalToConstant: width * self.visualStyle.width),
+                self.alert.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+                self.actionSheetBottomConstraint!,
+                self.alert.heightAnchor.constraint(lessThanOrEqualTo: self.view.heightAnchor,
+                                                   constant: -margins.top)
                 ])
-
-            case .alert:
-                self.alert.widthAnchor.constraint(equalToConstant: self.visualStyle.width).isActive = true
-                self.verticalCenter = self.alert.centerYAnchor.constraint(equalTo: self.view.centerYAnchor)
-                let maximumHeightOffset = -(margins.top + margins.bottom)
-
-                NSLayoutConstraint.activate([
-                    self.verticalCenter!,
-                    self.alert.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
-                    self.alert.heightAnchor.constraint(lessThanOrEqualTo: self.view.heightAnchor,
-                                                       multiplier: 1, constant: maximumHeightOffset),
+            
+        case .alert:
+            self.alert.widthAnchor.constraint(equalToConstant: self.visualStyle.width).isActive = true
+            self.verticalCenter = self.alert.centerYAnchor.constraint(equalTo: self.view.centerYAnchor)
+            let maximumHeightOffset = -(margins.top + margins.bottom)
+            
+            NSLayoutConstraint.activate([
+                self.verticalCenter!,
+                self.alert.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+                self.alert.heightAnchor.constraint(lessThanOrEqualTo: self.view.heightAnchor,
+                                                   multiplier: 1, constant: maximumHeightOffset),
                 ])
-
-                let priority = UILayoutPriority(rawValue: 500)
-                self.alert.setContentCompressionResistancePriority(priority, for: .vertical)
+            
+            let priority = UILayoutPriority(rawValue: 500)
+            self.alert.setContentCompressionResistancePriority(priority, for: .vertical)
         }
     }
 

--- a/Source/Views/ActionSheetView.xib
+++ b/Source/Views/ActionSheetView.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_0" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
         <capability name="Alignment constraints to the first baseline" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -31,7 +31,7 @@
                             <color key="textColor" red="0.55517578125" green="0.55517578125" blue="0.55517578125" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <view hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="olF-R0-P3x">
+                        <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="olF-R0-P3x">
                             <rect key="frame" x="0.0" y="0.0" width="323" height="59"/>
                             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <constraints>

--- a/Source/Views/ActionSheetView.xib
+++ b/Source/Views/ActionSheetView.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13122.17" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_0" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
         <capability name="Alignment constraints to the first baseline" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -20,13 +20,13 @@
                     <rect key="frame" x="0.0" y="0.0" width="323" height="173"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="Title" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="P7t-ji-MaB" customClass="SDCAlertLabel">
-                            <rect key="frame" x="0.0" y="15" width="323" height="16"/>
+                            <rect key="frame" x="0.0" y="10.5" width="323" height="16"/>
                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="13"/>
                             <color key="textColor" red="0.55517578125" green="0.55517578125" blue="0.55517578125" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" text="Message" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vfZ-Nd-gE5" customClass="SDCAlertLabel">
-                            <rect key="frame" x="0.0" y="33" width="323" height="11.5"/>
+                            <rect key="frame" x="0.0" y="28.5" width="323" height="16"/>
                             <fontDescription key="fontDescription" type="system" pointSize="13"/>
                             <color key="textColor" red="0.55517578125" green="0.55517578125" blue="0.55517578125" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
@@ -64,7 +64,7 @@
                         <constraint firstItem="vfZ-Nd-gE5" firstAttribute="leading" secondItem="P7t-ji-MaB" secondAttribute="leading" id="Tlz-eU-w1x"/>
                         <constraint firstItem="vfZ-Nd-gE5" firstAttribute="trailing" secondItem="P7t-ji-MaB" secondAttribute="trailing" id="dY4-6J-tca"/>
                         <constraint firstItem="P7t-ji-MaB" firstAttribute="width" secondItem="ZiE-E8-Ngj" secondAttribute="width" id="f4q-g8-eZy"/>
-                        <constraint firstItem="P7t-ji-MaB" firstAttribute="firstBaseline" secondItem="ZiE-E8-Ngj" secondAttribute="top" constant="27" id="jIA-Qb-2yN"/>
+                        <constraint firstItem="P7t-ji-MaB" firstAttribute="firstBaseline" secondItem="ZiE-E8-Ngj" secondAttribute="top" priority="250" constant="27" id="jIA-Qb-2yN"/>
                         <constraint firstAttribute="trailing" secondItem="olF-R0-P3x" secondAttribute="trailing" id="nTV-Fr-ik3"/>
                         <constraint firstItem="olF-R0-P3x" firstAttribute="leading" secondItem="ZiE-E8-Ngj" secondAttribute="leading" id="zkC-9f-pQS"/>
                     </constraints>


### PR DESCRIPTION
Changing default title top constraint priority so that custom views can autosize now! Also added a convenience init that takes in a custom view and auto sets it up as well as updated the example demo to show off the new functionality.

Fixes "Alternative to constraints for setting height #147"