### PR TITLE
Fix .dismissOnOutsideTap behavior

### DIFF
--- a/Source/AlertController.swift
+++ b/Source/AlertController.swift
@@ -353,7 +353,7 @@ public class AlertController: UIViewController {
     }
 
     private func addChromeTapHandlerIfNecessary() {
-        if self.behaviors.contains(.dismissOnOutsideTap) {
+        guard self.behaviors.contains(.dismissOnOutsideTap) else {
             return
         }
 

--- a/Source/AlertController.swift
+++ b/Source/AlertController.swift
@@ -353,7 +353,7 @@ public class AlertController: UIViewController {
     }
 
     private func addChromeTapHandlerIfNecessary() {
-        guard self.behaviors.contains(.dismissOnOutsideTap) else {
+        if !self.behaviors.contains(.dismissOnOutsideTap) {
             return
         }
 


### PR DESCRIPTION
From `8.0.0`, the actual behavior of `AlertBehaviors.dismissOnOutsideTap` is contrary.

This PR fixes the incorrect `if` condition in `AlertController.addChromeTapHandlerIfNecessary`.