### PR TITLE
Return no preferredAction for action sheets

### DIFF
--- a/Source/AlertController.swift
+++ b/Source/AlertController.swift
@@ -77,6 +77,10 @@ public class AlertController: UIViewController {
     @objc
     public var preferredAction: AlertAction? {
         get {
+            if self.preferredStyle == .actionSheet {
+                return nil
+            }
+
             let index = self.actions.index { $0.style == .preferred }
             return index != nil ? self.actions[index!] : nil
         }


### PR DESCRIPTION
The documentation for UIAlertController.preferredAction specifies this
is only relevant for alerts, so this mimics that behavior more
accurately.