### PR TITLE
Will be dismissed Closure

### DIFF
--- a/Source/AlertController.swift
+++ b/Source/AlertController.swift
@@ -111,9 +111,9 @@ public final class AlertController: UIViewController {
     @objc
     public var shouldDismissHandler: ((AlertAction?) -> Bool)?
     
-    /// A closure called before the alert is dismissed
+    /// A closure called before the alert is dismissed but only if done by own method and not manually
     @objc
-    public var willBeDismissedHandler: (() -> Void)?
+    public var willDismissHandler: (() -> Void)?
 
     /// A closure called when the alert is dismissed after an outside tap (when `dismissOnOutsideTap` behavior
     /// is enabled)
@@ -243,7 +243,7 @@ public final class AlertController: UIViewController {
     /// - parameter completion: An optional closure that's called when the dismissal finishes.
     @objc(dismissViewControllerAnimated:completion:)
     public override func dismiss(animated: Bool = true, completion: (() -> Void)? = nil) {
-        self.willBeDismissedHandler?()
+        self.willDismissHandler?()
         self.presentingViewController?.dismiss(animated: animated, completion: completion)
     }
 

--- a/Source/AlertController.swift
+++ b/Source/AlertController.swift
@@ -110,6 +110,10 @@ public final class AlertController: UIViewController {
     /// on an action. If it returns false, the AlertAction handler will not be executed.
     @objc
     public var shouldDismissHandler: ((AlertAction?) -> Bool)?
+    
+    /// A closure called before the alert is dismissed
+    @objc
+    public var willBeDismissedHandler: (() -> Void)?
 
     /// A closure called when the alert is dismissed after an outside tap (when `dismissOnOutsideTap` behavior
     /// is enabled)
@@ -239,6 +243,7 @@ public final class AlertController: UIViewController {
     /// - parameter completion: An optional closure that's called when the dismissal finishes.
     @objc(dismissViewControllerAnimated:completion:)
     public override func dismiss(animated: Bool = true, completion: (() -> Void)? = nil) {
+        self.willBeDismissedHandler?()
         self.presentingViewController?.dismiss(animated: animated, completion: completion)
     }
 


### PR DESCRIPTION
- DemoViewController.swift: Adds an optional closure that is called right before the AlertController is dismissed. This is intended as an entry point to call animations or any UI update on the container controller.

Note: I used _shouldDismissHandler_ as an entry point to update the UI of the controller that presented the alert. The idea was to update the UI right in the moment the AlertController started to animate its way out but _shouldDismissHandler_ is not called when an outside tap is performed, only on actions and _outsideTapHandler_ is called after the animation is done. I thought that it was faster and cleaner to just have a closure like _outsideTapHandler_ called right before the alert is dismissed by any reason.