### PR TITLE
Empty action supported.

### DIFF
--- a/Source/Views/ActionSheetView.swift
+++ b/Source/Views/ActionSheetView.swift
@@ -66,6 +66,10 @@ final class ActionSheetView: UIView, AlertControllerViewRepresentable {
     // MARK: - Private
 
     private func assignCancelAction() -> AlertAction? {
+        if actions.isEmpty {
+            return nil
+        }
+        
         if let cancelActionIndex = self.actions.firstIndex(where: { $0.style == .preferred }) {
             let cancelAction = self.actions[cancelActionIndex]
             self.actions.remove(at: cancelActionIndex)


### PR DESCRIPTION
Sometimes, when we are using custom view, we prefer not to have any action buttons.

The following change, supports empty actions. (If not, the following function will yield a crash)

Thanks.