### PR TITLE
Avoid ActionSheetView from consuming all pan events

### DIFF
--- a/Source/Views/ActionSheetView.swift
+++ b/Source/Views/ActionSheetView.swift
@@ -58,6 +58,7 @@ final class ActionSheetView: UIView, AlertControllerViewRepresentable {
         }
 
         let panGesture = UIPanGestureRecognizer()
+        panGesture.cancelsTouchesInView = false
         panGesture.addTarget(self.primaryView, action: #selector(self.primaryView.highlightAction(for:)))
         panGesture.addTarget(self.cancelView, action: #selector(self.cancelView.highlightAction(for:)))
         self.addGestureRecognizer(panGesture)


### PR DESCRIPTION
Avoid ActionSheetView from consuming all pan events without passing to custom view.

With the above patch, we can implement the feature as shown in https://www.youtube.com/watch?v=pBrHFcvpb98