### PR TITLE
Fix iOS 15 crash

### DIFF
--- a/Source/AlertVisualStyle.swift
+++ b/Source/AlertVisualStyle.swift
@@ -154,7 +154,7 @@ open class AlertVisualStyle: NSObject {
 
         switch alertStyle {
             case .alert:
-                if #available(iOS 11, *), UIApplication.shared.keyWindow!.safeAreaInsets.bottom > 0 {
+                if #available(iOS 11, *), UIApplication.shared.keyWindow?.safeAreaInsets.bottom ?? 0 > 0 {
                     self.margins = .zero
                 } else {
                     self.margins = UIEdgeInsets(top: 10, left: 0, bottom: 10, right: 0)
@@ -164,7 +164,7 @@ open class AlertVisualStyle: NSObject {
                 self.actionViewSize = CGSize(width: 90, height: 44)
 
             case .actionSheet:
-                if #available(iOS 11, *), UIApplication.shared.keyWindow!.safeAreaInsets.bottom > 0 {
+                if #available(iOS 11, *), UIApplication.shared.keyWindow?.safeAreaInsets.bottom ?? 0 > 0 {
                     self.margins = UIEdgeInsets(top: 30, left: 10, bottom: 0, right: 10)
                 } else {
                     self.margins = UIEdgeInsets(top: 30, left: 10, bottom: -10, right: 10)


### PR DESCRIPTION
We've started seeing crashes on iOS 15 when build using Xcode 13. It looks like `keyWindow` may be `nil` in certain scenarios (background launch, early in app life cycle?).