### PR TITLE
Moved "Headers" phase before "Compile Sources"

### DIFF
--- a/SDCAlertView.xcodeproj/project.pbxproj
+++ b/SDCAlertView.xcodeproj/project.pbxproj
@@ -189,9 +189,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = D2515EC61BC1A7D500ED606F /* Build configuration list for PBXNativeTarget "SDCAlertView" */;
 			buildPhases = (
+				D2515EBE1BC1A7D500ED606F /* Headers */,
 				D2515EBC1BC1A7D500ED606F /* Sources */,
 				D2515EBD1BC1A7D500ED606F /* Frameworks */,
-				D2515EBE1BC1A7D500ED606F /* Headers */,
 				D2515EBF1BC1A7D500ED606F /* Resources */,
 			);
 			buildRules = (


### PR DESCRIPTION
Thank you for the great library. I've recently updated Xcode to 13.4 and found that "Cycle in dependencies" error is seen on build time (I'm using your library as a depending framework and bulding from the source). 

This is because "Headers" phase is after "Compile Sources" phase.

The same kind of error also happens on Unify.  And it is fixed in the same way.
https://forum.unity.com/threads/xcode-version-13-3-13e113-error-cycle-in-dependencies.1268720/?utm_source=pocket_mylist

So I think it is a reasonable fix. Please consider merging this small pull request.
![スクリーンショット 2022-07-01 14 34 02](https://user-images.githubusercontent.com/705350/176833621-624384ba-348e-4114-b49a-1ffef394e405.png)
.