### PR TITLE
Fix Transition reference collision with iOS 18 API

### DIFF
--- a/Source/AlertController.swift
+++ b/Source/AlertController.swift
@@ -130,7 +130,7 @@ public final class AlertController: UIViewController {
     public let preferredStyle: AlertControllerStyle
 
     private let alert: UIView & AlertControllerViewRepresentable
-    private lazy var transitionDelegate = Transition(alertStyle: self.preferredStyle,
+    private lazy var transitionDelegate = SDCAlertView.Transition(alertStyle: self.preferredStyle,
                                                      dimmingViewColor: self.visualStyle.dimmingColor)
 
     // MARK: - Initialization


### PR DESCRIPTION
This fixes the issue of name collision with UIKit.UIViewControllerTransition.Transition which was making the build fail on Xcode 16 beta