### PR TITLE
Rename class Transition to SDCTransition

### DIFF
--- a/Source/AlertController.swift
+++ b/Source/AlertController.swift
@@ -130,7 +130,7 @@ public final class AlertController: UIViewController {
     public let preferredStyle: AlertControllerStyle
 
     private let alert: UIView & AlertControllerViewRepresentable
-    private lazy var transitionDelegate = SDCAlertView.Transition(alertStyle: self.preferredStyle,
+    private lazy var transitionDelegate = SDCTransition(alertStyle: self.preferredStyle,
                                                      dimmingViewColor: self.visualStyle.dimmingColor)
 
     // MARK: - Initialization

--- a/Source/Presentation/Transition.swift
+++ b/Source/Presentation/Transition.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class Transition: NSObject, UIViewControllerTransitioningDelegate {
+class SDCTransition: NSObject, UIViewControllerTransitioningDelegate {
 
     private let alertStyle: AlertControllerStyle
     private let dimmingViewColor: UIColor


### PR DESCRIPTION
Rename class Transition to SDCTransition to fix class name conflict in Xcode 16.