### PR TITLE
feat: Add ability to call the Acction handlers before it is dissmissed

### DIFF
--- a/Source/AlertController.swift
+++ b/Source/AlertController.swift
@@ -129,6 +129,9 @@ public final class AlertController: UIViewController {
     @objc
     public let preferredStyle: AlertControllerStyle
 
+    @objc
+    public var callActionHandlerImmediatelly: Bool = false
+
     private let alert: UIView & AlertControllerViewRepresentable
     private lazy var transitionDelegate = SDCTransition(alertStyle: self.preferredStyle,
                                                      dimmingViewColor: self.visualStyle.dimmingColor)
@@ -327,8 +330,13 @@ public final class AlertController: UIViewController {
         self.alert.prepareLayout()
         self.alert.actionTappedHandler = { [weak self] action in
             if self?.shouldDismissHandler?(action) != false {
-                self?.dismiss(animated: true) {
+                if self?.callActionHandlerImmediatelly ?? false {
                     action.handler?(action)
+                }
+                self?.dismiss(animated: true) {
+                    if !(self?.callActionHandlerImmediatelly ?? false) {
+                        action.handler?(action)
+                    }
                 }
             }
         }

--- a/Source/AlertController.swift
+++ b/Source/AlertController.swift
@@ -129,6 +129,7 @@ public final class AlertController: UIViewController {
     @objc
     public let preferredStyle: AlertControllerStyle
 
+    /// true to call the action before alert dissmiss, false to wait for dissmiss completion
     @objc
     public var callActionHandlerImmediatelly: Bool = false
 


### PR DESCRIPTION
Hi,

I needed to call the action immediatelly after the button is clicked (not after the alert is dissmissed).
Would it be possible to merge in?